### PR TITLE
Add feature to use tags as functions (for chaining when already using tags)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,12 +12,13 @@ improving the display of
 [string template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)
 in your source.
 
-This module provides a template literal tag that removes line breaks and indents
+This module provides template literal tags that remove line breaks and indents
 from your template literals, so that a string that is formatted to nicely fit in
-your code still comes out looking like it should.
+your code still comes out looking like it should. They are also
+[chainable](#Chaining) in case you are already using template literal tags.
 
-This allows you to keep all lines of code within whatever limit you prefer
-without having to resort to hacks like adding each line of string to the
+This allows you to keep all lines of code within whatever length limit you
+prefer without having to resort to hacks like adding each line of string to the
 previous or escaping each linebreak.
 
 ```js
@@ -100,6 +101,21 @@ newline character instead of an actual linebreak. For example:
 let E = c`This has\n a new line`;
 // => This has
 // a new line.
+```
+
+### Chaining
+One drawback to using template literal tags is that they cannot be chained. This
+means that if you are already using template literal tags, you can't use these
+as described above. All of these tags, however, do support being used as normal
+functions in this case:
+
+```js
+// Assuming `capitalize` is some other tag that makes every letter uppercase:
+let F = c(capitalize`
+  Lorem ipsum
+  dolor sit amet.
+`);
+// => LOREM IPSUM DOLOR SIT AMET.
 ```
 
 ## Contributing

--- a/readme.md
+++ b/readme.md
@@ -98,16 +98,16 @@ You can still output a string that has linebreaks in it simply by using the
 newline character instead of an actual linebreak. For example:
 
 ```js
-let E = c`This has\n a new line`;
+let E = c`This has\n\ta new line`;
 // => This has
-// a new line.
+//     a new line.
 ```
 
 ### Chaining
 One drawback to using template literal tags is that they cannot be chained. This
 means that if you are already using template literal tags, you can't use these
-as described above. All of these tags, however, do support being used as normal
-functions in this case:
+as described above. All of these tags support being used as normal functions in
+this case\*:
 
 ```js
 // Assuming `capitalize` is some other tag that makes every letter uppercase:
@@ -116,6 +116,18 @@ let F = c(capitalize`
   dolor sit amet.
 `);
 // => LOREM IPSUM DOLOR SIT AMET.
+```
+
+\* **Note**: A side effect of using the tags as a method is that if you want to
+preserve linebreaks or tabs, you must add them as `\\n` or `\\t` instead of
+`\n` or `\t` as described [above](#preserving-some-linebreaks). A PR to fix this
+would be welcomed.
+
+Example (note the lack of linebreak between *dolor* and *sit*):
+```js
+let F = c(capitalize`Lorem ipsum \\n dolor \n sit amet.`);
+// => LOREM IPSUM
+//DOLOR SIT AMET.
 ```
 
 ## Contributing

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -363,23 +363,23 @@ context("compress-tag", function(): void {
         it("should not modify single word strings", function(): void {
           assert.strictEqual(compress(`test`), `test`);
         });
-  
+
         it("should not modify single line strings", function(): void {
           assert.strictEqual(compress(`this IS a tEst`), `this IS a tEst`);
         });
-  
+
         it("should handle string placeholders properly", function(): void {
           assert.strictEqual(
             compress(`this ${"is"} a ${"test with"} some ${""} strings`),
             `this ${"is"} a ${"test with"} some ${""} strings`
           );
-  
+
           assert.strictEqual(
             compress(`this has ${""}empty ${""} strings`),
             `this has ${""}empty ${""} strings`
           );
         });
-  
+
         it("should handle numeric placeholders properly", function(): void {
           assert.strictEqual(
             compress(`${1} | ${2} | ${0}`),
@@ -388,25 +388,25 @@ context("compress-tag", function(): void {
           assert.strictEqual(compress(`${NaN}`), `${NaN}`);
           assert.strictEqual(compress(`${Infinity}`), `${Infinity}`);
         });
-  
+
         it("should handle expression placeholders properly", function(): void {
           assert.strictEqual(compress(`${1 + 456}`), `${1 + 456}`);
           assert.strictEqual(compress(`${Math.sqrt(2)}`), `${Math.sqrt(2)}`);
         });
-  
+
         it("should handle undefined placeholder properly", function(): void {
           assert.strictEqual(compress(`${undefined}`), `${undefined}`);
         });
-  
+
         it("should handle null placeholder properly", function(): void {
           assert.strictEqual(compress(`${null}`), `${null}`);
         });
-  
+
         it("should handle object placeholder properly", function(): void {
           const obj = {x: 56};
           assert.strictEqual(compress(`${obj}`), `${obj}`);
         });
-  
+
         it("should correctly process all known escape sequences", function(): void {
           assert.strictEqual(
             compress(`\\r\\t\\n\\0\\v\\f\\b\\\\'\\"`),
@@ -414,7 +414,7 @@ context("compress-tag", function(): void {
           );
         });
       });
-  
+
       describe("removes all newlines and replaces with a space", function(): void {
         it("should remove format newlines", function(): void {
           assert.strictEqual(
@@ -423,21 +423,21 @@ context("compress-tag", function(): void {
             "this has a new line"
           );
         });
-  
+
         it("should not remove manual CRLF newlines", function(): void {
           assert.strictEqual(
             compress(`this has \\r\\n a new line`),
             "this has \r\n a new line"
           );
         });
-  
+
         it("should not remove manual LF newlines", function(): void {
           assert.strictEqual(
             compress(`this has \\n a new line`),
             "this has \n a new line"
           );
         });
-  
+
         it("should remove consecutive newlines without inserting multiple spaces", function(): void {
           assert.strictEqual(
             compress(`this has
@@ -449,15 +449,15 @@ context("compress-tag", function(): void {
             "this has several new lines"
           );
         });
-  
+
         it("should remove leading newlines without leaving leading spaces", function(): void {
           assert.strictEqual(
-            (compress`
-  this has a leading new line`),
+            compress`
+  this has a leading new line`,
             "this has a leading new line"
           );
         });
-  
+
         it("should remove trailing newlines without leaving trailing spaces", function(): void {
           assert.strictEqual(
             compress(`this has a trailing new line
@@ -465,7 +465,7 @@ context("compress-tag", function(): void {
             "this has a trailing new line"
           );
         });
-  
+
         it("should remove multiple non-connected newlines", function(): void {
           assert.strictEqual(
             compress(`this
@@ -476,7 +476,7 @@ context("compress-tag", function(): void {
           );
         });
       });
-  
+
       describe("removes whitespace from around individual lines", function(): void {
         it("should remove leading spaces from lines", function(): void {
           assert.strictEqual(
@@ -487,7 +487,7 @@ context("compress-tag", function(): void {
             "this has indented lines with leading spaces"
           );
         });
-  
+
         it("should remove trailing spaces from lines", function(): void {
           assert.strictEqual(
             compress(`this has 
@@ -497,7 +497,7 @@ context("compress-tag", function(): void {
             "this has lines with trailing spaces"
           );
         });
-  
+
         it("should remove tabs from lines", function(): void {
           /* eslint-disable no-tabs */
           assert.strictEqual(
@@ -508,7 +508,7 @@ context("compress-tag", function(): void {
           );
           /* eslint-enable no-tabs */
         });
-  
+
         it("should not affect internal whitespace", function(): void {
           /* eslint-disable no-tabs */
           assert.strictEqual(
@@ -519,7 +519,7 @@ context("compress-tag", function(): void {
           );
           /* eslint-enable no-tabs */
         });
-  
+
         it("should not affect manual tabs", function(): void {
           assert.strictEqual(
             compress(`this has 
@@ -529,29 +529,29 @@ context("compress-tag", function(): void {
         });
       });
     });
-  
+
     context("#compressTight", function(): void {
       describe("properly resolves template literals", function(): void {
         it("should not modify single word strings", function(): void {
           assert.strictEqual(compressTight(`test`), `test`);
         });
-  
+
         it("should not modify single line strings", function(): void {
           assert.strictEqual(compressTight(`this IS a tEst`), `this IS a tEst`);
         });
-  
+
         it("should handle string placeholders properly", function(): void {
           assert.strictEqual(
             compressTight(`this ${"is"} a ${"test with"} some ${""} strings`),
             `this ${"is"} a ${"test with"} some ${""} strings`
           );
-  
+
           assert.strictEqual(
             compressTight(`this has ${""}empty ${""} strings`),
             `this has ${""}empty ${""} strings`
           );
         });
-  
+
         it("should handle numeric placeholders properly", function(): void {
           assert.strictEqual(
             compressTight(`${1} | ${2} | ${0}`),
@@ -560,33 +560,36 @@ context("compress-tag", function(): void {
           assert.strictEqual(compressTight(`${NaN}`), `${NaN}`);
           assert.strictEqual(compressTight(`${Infinity}`), `${Infinity}`);
         });
-  
+
         it("should handle expression placeholders properly", function(): void {
           assert.strictEqual(compressTight(`${1 + 456}`), `${1 + 456}`);
-          assert.strictEqual(compressTight(`${Math.sqrt(2)}`), `${Math.sqrt(2)}`);
+          assert.strictEqual(
+            compressTight(`${Math.sqrt(2)}`),
+            `${Math.sqrt(2)}`
+          );
         });
-  
+
         it("should handle undefined placeholder properly", function(): void {
           assert.strictEqual(compressTight(`${undefined}`), `${undefined}`);
         });
-  
+
         it("should handle null placeholder properly", function(): void {
           assert.strictEqual(compressTight(`${null}`), `${null}`);
         });
-  
+
         it("should handle object placeholder properly", function(): void {
           const obj = {x: 56};
           assert.strictEqual(compressTight(`${obj}`), `${obj}`);
         });
-  
+
         it("should correctly process all known escape sequences", function(): void {
           assert.strictEqual(
-            (compressTight(`\\r\\t\\n\\0\\v\\f\\b\\\\'\\"`)),
+            compressTight(`\\r\\t\\n\\0\\v\\f\\b\\\\'\\"`),
             `\r\t\n\0\v\f\b\\\'\"` // eslint-disable-line no-useless-escape
           );
         });
       });
-  
+
       describe("removes all newlines and does not replace with a space", function(): void {
         it("should remove format newlines", function(): void {
           assert.strictEqual(
@@ -595,21 +598,21 @@ context("compress-tag", function(): void {
             "this hasa new line"
           );
         });
-  
+
         it("should not remove manual CRLF newlines", function(): void {
           assert.strictEqual(
             compressTight(`this has \\r\\n a new line`),
             "this has \r\n a new line"
           );
         });
-  
+
         it("should not remove manual LF newlines", function(): void {
           assert.strictEqual(
             compressTight(`this has \\n a new line`),
             "this has \n a new line"
           );
         });
-  
+
         it("should remove consecutive newlines without inserting multiple spaces", function(): void {
           assert.strictEqual(
             compressTight(`this has
@@ -621,15 +624,15 @@ context("compress-tag", function(): void {
             "this hasseveral new lines"
           );
         });
-  
+
         it("should remove leading newlines without leaving leading spaces", function(): void {
           assert.strictEqual(
-            (compressTight`
-  this has a leading new line`),
+            compressTight`
+  this has a leading new line`,
             "this has a leading new line"
           );
         });
-  
+
         it("should remove trailing newlines without leaving trailing spaces", function(): void {
           assert.strictEqual(
             compressTight(`this has a trailing new line
@@ -637,7 +640,7 @@ context("compress-tag", function(): void {
             "this has a trailing new line"
           );
         });
-  
+
         it("should remove multiple non-connected newlines", function(): void {
           assert.strictEqual(
             compressTight(`this
@@ -648,7 +651,7 @@ context("compress-tag", function(): void {
           );
         });
       });
-  
+
       describe("removes whitespace from around individual lines", function(): void {
         it("should remove leading spaces from lines", function(): void {
           assert.strictEqual(
@@ -659,7 +662,7 @@ context("compress-tag", function(): void {
             "this hasindented lineswith leadingspaces"
           );
         });
-  
+
         it("should remove trailing spaces from lines", function(): void {
           assert.strictEqual(
             compressTight(`this has 
@@ -669,7 +672,7 @@ context("compress-tag", function(): void {
             "this haslineswith trailingspaces"
           );
         });
-  
+
         it("should remove tabs from lines", function(): void {
           /* eslint-disable no-tabs */
           assert.strictEqual(
@@ -680,7 +683,7 @@ context("compress-tag", function(): void {
           );
           /* eslint-enable no-tabs */
         });
-  
+
         it("should not affect internal whitespace", function(): void {
           /* eslint-disable no-tabs */
           assert.strictEqual(
@@ -691,7 +694,7 @@ context("compress-tag", function(): void {
           );
           /* eslint-enable no-tabs */
         });
-  
+
         it("should not affect manual tabs", function(): void {
           assert.strictEqual(
             compressTight(`this has 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -409,7 +409,7 @@ context("compress-tag", function(): void {
   
         it("should correctly process all known escape sequences", function(): void {
           assert.strictEqual(
-            compress(`\r\t\n\0\v\f\b\\\'\"`),
+            compress(`\\r\\t\\n\\0\\v\\f\\b\\\\'\\"`),
             `\r\t\n\0\v\f\b\\\'\"` // eslint-disable-line no-useless-escape
           );
         });
@@ -426,14 +426,14 @@ context("compress-tag", function(): void {
   
         it("should not remove manual CRLF newlines", function(): void {
           assert.strictEqual(
-            compress(`this has \r\n a new line`),
+            compress(`this has \\r\\n a new line`),
             "this has \r\n a new line"
           );
         });
   
         it("should not remove manual LF newlines", function(): void {
           assert.strictEqual(
-            compress(`this has \n a new line`),
+            compress(`this has \\n a new line`),
             "this has \n a new line"
           );
         });
@@ -523,7 +523,7 @@ context("compress-tag", function(): void {
         it("should not affect manual tabs", function(): void {
           assert.strictEqual(
             compress(`this has 
-          \ta manual tab`),
+          \\ta manual tab`),
             "this has \ta manual tab"
           );
         });
@@ -581,7 +581,7 @@ context("compress-tag", function(): void {
   
         it("should correctly process all known escape sequences", function(): void {
           assert.strictEqual(
-            (compressTight(`\r\t\n\0\v\f\b\\\'\"`)),
+            (compressTight(`\\r\\t\\n\\0\\v\\f\\b\\\\'\\"`)),
             `\r\t\n\0\v\f\b\\\'\"` // eslint-disable-line no-useless-escape
           );
         });
@@ -598,14 +598,14 @@ context("compress-tag", function(): void {
   
         it("should not remove manual CRLF newlines", function(): void {
           assert.strictEqual(
-            compressTight(`this has \r\n a new line`),
+            compressTight(`this has \\r\\n a new line`),
             "this has \r\n a new line"
           );
         });
   
         it("should not remove manual LF newlines", function(): void {
           assert.strictEqual(
-            compressTight(`this has \n a new line`),
+            compressTight(`this has \\n a new line`),
             "this has \n a new line"
           );
         });
@@ -695,7 +695,7 @@ context("compress-tag", function(): void {
         it("should not affect manual tabs", function(): void {
           assert.strictEqual(
             compressTight(`this has 
-          \ta manual tab`),
+          \\ta manual tab`),
             "this has\ta manual tab"
           );
         });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -235,7 +235,7 @@ context("compress-tag", function(): void {
 
         it("should correctly process all known escape sequences", function(): void {
           assert.strictEqual(
-            compress`\r\t\n\0\v\f\b\\\'\"`,
+            compressTight`\r\t\n\0\v\f\b\\\'\"`,
             `\r\t\n\0\v\f\b\\\'\"` // eslint-disable-line no-useless-escape
           );
         });
@@ -350,6 +350,352 @@ context("compress-tag", function(): void {
           assert.strictEqual(
             compressTight`this has 
           \ta manual tab`,
+            "this has\ta manual tab"
+          );
+        });
+      });
+    });
+  });
+
+  context("Behaviour As Methods", function(): void {
+    context("#compress", function(): void {
+      describe("properly resolves template literals", function(): void {
+        it("should not modify single word strings", function(): void {
+          assert.strictEqual(compress(`test`), `test`);
+        });
+  
+        it("should not modify single line strings", function(): void {
+          assert.strictEqual(compress(`this IS a tEst`), `this IS a tEst`);
+        });
+  
+        it("should handle string placeholders properly", function(): void {
+          assert.strictEqual(
+            compress(`this ${"is"} a ${"test with"} some ${""} strings`),
+            `this ${"is"} a ${"test with"} some ${""} strings`
+          );
+  
+          assert.strictEqual(
+            compress(`this has ${""}empty ${""} strings`),
+            `this has ${""}empty ${""} strings`
+          );
+        });
+  
+        it("should handle numeric placeholders properly", function(): void {
+          assert.strictEqual(
+            compress(`${1} | ${2} | ${0}`),
+            `${1} | ${2} | ${0}`
+          );
+          assert.strictEqual(compress(`${NaN}`), `${NaN}`);
+          assert.strictEqual(compress(`${Infinity}`), `${Infinity}`);
+        });
+  
+        it("should handle expression placeholders properly", function(): void {
+          assert.strictEqual(compress(`${1 + 456}`), `${1 + 456}`);
+          assert.strictEqual(compress(`${Math.sqrt(2)}`), `${Math.sqrt(2)}`);
+        });
+  
+        it("should handle undefined placeholder properly", function(): void {
+          assert.strictEqual(compress(`${undefined}`), `${undefined}`);
+        });
+  
+        it("should handle null placeholder properly", function(): void {
+          assert.strictEqual(compress(`${null}`), `${null}`);
+        });
+  
+        it("should handle object placeholder properly", function(): void {
+          const obj = {x: 56};
+          assert.strictEqual(compress(`${obj}`), `${obj}`);
+        });
+  
+        it("should correctly process all known escape sequences", function(): void {
+          assert.strictEqual(
+            compress(`\r\t\n\0\v\f\b\\\'\"`),
+            `\r\t\n\0\v\f\b\\\'\"` // eslint-disable-line no-useless-escape
+          );
+        });
+      });
+  
+      describe("removes all newlines and replaces with a space", function(): void {
+        it("should remove format newlines", function(): void {
+          assert.strictEqual(
+            compress(`this has
+  a new line`),
+            "this has a new line"
+          );
+        });
+  
+        it("should not remove manual CRLF newlines", function(): void {
+          assert.strictEqual(
+            compress(`this has \r\n a new line`),
+            "this has \r\n a new line"
+          );
+        });
+  
+        it("should not remove manual LF newlines", function(): void {
+          assert.strictEqual(
+            compress(`this has \n a new line`),
+            "this has \n a new line"
+          );
+        });
+  
+        it("should remove consecutive newlines without inserting multiple spaces", function(): void {
+          assert.strictEqual(
+            compress(`this has
+  
+  
+  
+  
+  several new lines`),
+            "this has several new lines"
+          );
+        });
+  
+        it("should remove leading newlines without leaving leading spaces", function(): void {
+          assert.strictEqual(
+            (compress`
+  this has a leading new line`),
+            "this has a leading new line"
+          );
+        });
+  
+        it("should remove trailing newlines without leaving trailing spaces", function(): void {
+          assert.strictEqual(
+            compress(`this has a trailing new line
+  `),
+            "this has a trailing new line"
+          );
+        });
+  
+        it("should remove multiple non-connected newlines", function(): void {
+          assert.strictEqual(
+            compress(`this
+  has several
+  new
+  lines`),
+            "this has several new lines"
+          );
+        });
+      });
+  
+      describe("removes whitespace from around individual lines", function(): void {
+        it("should remove leading spaces from lines", function(): void {
+          assert.strictEqual(
+            compress(`this has 
+            indented lines 
+            with leading
+            spaces`),
+            "this has indented lines with leading spaces"
+          );
+        });
+  
+        it("should remove trailing spaces from lines", function(): void {
+          assert.strictEqual(
+            compress(`this has 
+  lines          
+  with trailing                      
+  spaces`),
+            "this has lines with trailing spaces"
+          );
+        });
+  
+        it("should remove tabs from lines", function(): void {
+          /* eslint-disable no-tabs */
+          assert.strictEqual(
+            compress(`this has 
+                  tab characters					 
+  around a line`),
+            "this has tab characters around a line"
+          );
+          /* eslint-enable no-tabs */
+        });
+  
+        it("should not affect internal whitespace", function(): void {
+          /* eslint-disable no-tabs */
+          assert.strictEqual(
+            compress(`this has
+          internal          and external tabs				and
+          spaces`),
+            "this has internal          and external tabs				and spaces"
+          );
+          /* eslint-enable no-tabs */
+        });
+  
+        it("should not affect manual tabs", function(): void {
+          assert.strictEqual(
+            compress(`this has 
+          \ta manual tab`),
+            "this has \ta manual tab"
+          );
+        });
+      });
+    });
+  
+    context("#compressTight", function(): void {
+      describe("properly resolves template literals", function(): void {
+        it("should not modify single word strings", function(): void {
+          assert.strictEqual(compressTight(`test`), `test`);
+        });
+  
+        it("should not modify single line strings", function(): void {
+          assert.strictEqual(compressTight(`this IS a tEst`), `this IS a tEst`);
+        });
+  
+        it("should handle string placeholders properly", function(): void {
+          assert.strictEqual(
+            compressTight(`this ${"is"} a ${"test with"} some ${""} strings`),
+            `this ${"is"} a ${"test with"} some ${""} strings`
+          );
+  
+          assert.strictEqual(
+            compressTight(`this has ${""}empty ${""} strings`),
+            `this has ${""}empty ${""} strings`
+          );
+        });
+  
+        it("should handle numeric placeholders properly", function(): void {
+          assert.strictEqual(
+            compressTight(`${1} | ${2} | ${0}`),
+            `${1} | ${2} | ${0}`
+          );
+          assert.strictEqual(compressTight(`${NaN}`), `${NaN}`);
+          assert.strictEqual(compressTight(`${Infinity}`), `${Infinity}`);
+        });
+  
+        it("should handle expression placeholders properly", function(): void {
+          assert.strictEqual(compressTight(`${1 + 456}`), `${1 + 456}`);
+          assert.strictEqual(compressTight(`${Math.sqrt(2)}`), `${Math.sqrt(2)}`);
+        });
+  
+        it("should handle undefined placeholder properly", function(): void {
+          assert.strictEqual(compressTight(`${undefined}`), `${undefined}`);
+        });
+  
+        it("should handle null placeholder properly", function(): void {
+          assert.strictEqual(compressTight(`${null}`), `${null}`);
+        });
+  
+        it("should handle object placeholder properly", function(): void {
+          const obj = {x: 56};
+          assert.strictEqual(compressTight(`${obj}`), `${obj}`);
+        });
+  
+        it("should correctly process all known escape sequences", function(): void {
+          assert.strictEqual(
+            (compressTight(`\r\t\n\0\v\f\b\\\'\"`)),
+            `\r\t\n\0\v\f\b\\\'\"` // eslint-disable-line no-useless-escape
+          );
+        });
+      });
+  
+      describe("removes all newlines and does not replace with a space", function(): void {
+        it("should remove format newlines", function(): void {
+          assert.strictEqual(
+            compressTight(`this has
+  a new line`),
+            "this hasa new line"
+          );
+        });
+  
+        it("should not remove manual CRLF newlines", function(): void {
+          assert.strictEqual(
+            compressTight(`this has \r\n a new line`),
+            "this has \r\n a new line"
+          );
+        });
+  
+        it("should not remove manual LF newlines", function(): void {
+          assert.strictEqual(
+            compressTight(`this has \n a new line`),
+            "this has \n a new line"
+          );
+        });
+  
+        it("should remove consecutive newlines without inserting multiple spaces", function(): void {
+          assert.strictEqual(
+            compressTight(`this has
+  
+  
+  
+  
+  several new lines`),
+            "this hasseveral new lines"
+          );
+        });
+  
+        it("should remove leading newlines without leaving leading spaces", function(): void {
+          assert.strictEqual(
+            (compressTight`
+  this has a leading new line`),
+            "this has a leading new line"
+          );
+        });
+  
+        it("should remove trailing newlines without leaving trailing spaces", function(): void {
+          assert.strictEqual(
+            compressTight(`this has a trailing new line
+  `),
+            "this has a trailing new line"
+          );
+        });
+  
+        it("should remove multiple non-connected newlines", function(): void {
+          assert.strictEqual(
+            compressTight(`this
+  has several
+  new
+  lines`),
+            "thishas severalnewlines"
+          );
+        });
+      });
+  
+      describe("removes whitespace from around individual lines", function(): void {
+        it("should remove leading spaces from lines", function(): void {
+          assert.strictEqual(
+            compressTight(`this has 
+            indented lines 
+            with leading
+            spaces`),
+            "this hasindented lineswith leadingspaces"
+          );
+        });
+  
+        it("should remove trailing spaces from lines", function(): void {
+          assert.strictEqual(
+            compressTight(`this has 
+  lines          
+  with trailing                      
+  spaces`),
+            "this haslineswith trailingspaces"
+          );
+        });
+  
+        it("should remove tabs from lines", function(): void {
+          /* eslint-disable no-tabs */
+          assert.strictEqual(
+            compressTight(`this has 
+                  tab characters					
+  around a line`),
+            "this hastab charactersaround a line"
+          );
+          /* eslint-enable no-tabs */
+        });
+  
+        it("should not affect internal whitespace", function(): void {
+          /* eslint-disable no-tabs */
+          assert.strictEqual(
+            compressTight(`this has
+          internal          and external tabs				and
+          spaces`),
+            "this hasinternal          and external tabs				andspaces"
+          );
+          /* eslint-enable no-tabs */
+        });
+  
+        it("should not affect manual tabs", function(): void {
+          assert.strictEqual(
+            compressTight(`this has 
+          \ta manual tab`),
             "this has\ta manual tab"
           );
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,10 +74,6 @@ function deescape(raw: string): string {
   );
 }
 
-function replaceBreaksAndTrim(text: string, tight: boolean) {
-  return text.replace(/\s*[\r\n]+\s*/g, tight ? "" : " ").trim();
-}
-
 /**
  * Generate a template literal tag that compresses (AKA minifies) a template
  * string. In this context, compress is defined as removing line breaks and
@@ -101,7 +97,10 @@ function generateCompressTag(
             Array.from((stringOrStrings as TemplateStringsArray).raw),
             placeholders
           ).reduce((result, element): string => result + element, "");
-    return deescape(replaceBreaksAndTrim(combined, tight));
+
+    return deescape(
+      combined.replace(/\s*[\r\n]+\s*/g, tight ? "" : " ").trim()
+    );
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,14 +94,13 @@ function generateCompressTag(
   tight: boolean = false
 ): ChainableTemplateLiteralTag {
   return function(stringOrStrings, ...placeholders): string {
-    if (typeof stringOrStrings === "string") {
-      return replaceBreaksAndTrim(stringOrStrings, tight);
-    }
-
-    const combined = merge(
-      Array.from((stringOrStrings as TemplateStringsArray).raw),
-      placeholders
-    ).reduce((result, element): string => result + element, "");
+    const combined =
+      typeof stringOrStrings === "string"
+        ? stringOrStrings
+        : merge(
+            Array.from((stringOrStrings as TemplateStringsArray).raw),
+            placeholders
+          ).reduce((result, element): string => result + element, "");
     return deescape(replaceBreaksAndTrim(combined, tight));
   };
 }
@@ -110,7 +109,7 @@ function generateCompressTag(
  * Parses the string and placeholders as normal, then removes any line breaks
  * and the spaces surrounding each line (ie, indentation), replacing each line
  * break with a single space. Empty lines are removed completely.
- * 
+ *
  * Can be used either as a template literal tag or as a function that accepts
  * a string. This section option is used when the template literal already must
  * be tagged with some other tag.
@@ -149,7 +148,7 @@ export const compress = generateCompressTag();
 /**
  * Parses the string and placeholders as normal, then removes any line breaks
  * and the spaces surrounding each line (ie, indentation).
- * 
+ *
  * Can be used either as a template literal tag or as a function that accepts
  * a string. This section option is used when the template literal already must
  * be tagged with some other tag.
@@ -189,7 +188,7 @@ export const compressTight = generateCompressTag(true);
  * Parses the string and placeholders as normal, then removes any line breaks
  * and the spaces surrounding each line (ie, indentation), replacing each line
  * break with a single space. Empty lines are removed completely.
- * 
+ *
  * Can be used either as a template literal tag or as a function that accepts
  * a string. This section option is used when the template literal already must
  * be tagged with some other tag.
@@ -228,7 +227,7 @@ export const c = compress;
 /**
  * Parses the string and placeholders as normal, then removes any line breaks
  * and the spaces surrounding each line (ie, indentation).
- * 
+ *
  * Can be used either as a template literal tag or as a function that accepts
  * a string. This section option is used when the template literal already must
  * be tagged with some other tag.


### PR DESCRIPTION
Enables the use of the tags as regular functions that take a single string as their only argument. This allows for chaining, ie:
```js
let F = c(capitalize`
  Lorem ipsum
  dolor sit amet.
`);
// => LOREM IPSUM DOLOR SIT AMET.
```